### PR TITLE
Adjust Velero to custom needs

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -202,7 +202,7 @@ type VolumeSnapshotterGetter interface {
 // back up individual resources that don't prevent the backup from continuing to be processed) are logged
 // to the backup log.
 func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Request, backupFile io.Writer, actions []velero.BackupItemAction, volumeSnapshotterGetter VolumeSnapshotterGetter) error {
-	// NOTE(freyjo): This requires that the BackupStorageLocation must always be named exactly as the target cluster.
+	// NOTE: This requires that the BackupStorageLocation must always be named exactly as the target cluster.
 	clusterName := backupRequest.StorageLocation.Name
 	clientSet, dynamicClient, err := kube.NewClusterClients(context.Background(), kb.client, kbclient.ObjectKey{
 		Namespace: backupRequest.Namespace,

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -101,6 +101,8 @@ func cohabitatingResources() map[string]*cohabitatingResource {
 // NewKubernetesBackupper creates a new kubernetesBackupper.
 func NewKubernetesBackupper(
 	backupClient velerov1client.BackupsGetter,
+	discoveryHelper discovery.Helper,
+	dynamicFactory client.DynamicFactory,
 	client kbclient.Client,
 	podCommandExecutor podexec.PodCommandExecutor,
 	resticBackupperFactory restic.BackupperFactory,

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -224,10 +224,6 @@ func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Req
 	log.Infof("Backing up all pod volumes using restic: %t", *backupRequest.Backup.Spec.DefaultVolumesToRestic)
 
 	var err error
-	backupRequest.ResourceHooks, err = getResourceHooks(backupRequest.Spec.Hooks.Resources, kb.discoveryHelper)
-	if err != nil {
-		return err
-	}
 
 	backupRequest.ResolvedActions, err = resolveActions(actions, kb.discoveryHelper)
 	if err != nil {
@@ -291,9 +287,6 @@ func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Req
 		resticBackupper:         resticBackupper,
 		resticSnapshotTracker:   newPVCSnapshotTracker(),
 		volumeSnapshotterGetter: volumeSnapshotterGetter,
-		itemHookHandler: &hook.DefaultItemHookHandler{
-			PodCommandExecutor: kb.podCommandExecutor,
-		},
 	}
 
 	// helper struct to send current progress between the main

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -120,6 +120,8 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 
 	log.Info("Backing up item")
 
+	// Because we don't want to use hooks.
+	//
 	//log.Debug("Executing pre hooks")
 	//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre); err != nil {
 	//	return false, err
@@ -172,6 +174,8 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		backupErrs = append(backupErrs, err)
 
 		// if there was an error running actions, execute post hooks and return
+		// Because we don't want to use hooks.
+		//
 		//log.Debug("Executing post hooks")
 		//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
 		//	backupErrs = append(backupErrs, err)
@@ -202,6 +206,8 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		backupErrs = append(backupErrs, errs...)
 	}
 
+	// Because we don't want to use hooks.
+	//
 	//log.Debug("Executing post hooks")
 	//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
 	//	backupErrs = append(backupErrs, err)

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -121,8 +121,10 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 	log.Info("Backing up item")
 
 	log.Debug("Executing pre hooks")
-	if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre); err != nil {
-		return false, err
+	if ib.itemHookHandler != nil {
+		if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre); err != nil {
+			return false, err
+		}
 	}
 
 	var (
@@ -173,8 +175,10 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 
 		// if there was an error running actions, execute post hooks and return
 		log.Debug("Executing post hooks")
-		if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
-			backupErrs = append(backupErrs, err)
+		if ib.itemHookHandler != nil {
+			if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
+				backupErrs = append(backupErrs, err)
+			}
 		}
 
 		return false, kubeerrs.NewAggregate(backupErrs)
@@ -203,8 +207,10 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 	}
 
 	log.Debug("Executing post hooks")
-	if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
-		backupErrs = append(backupErrs, err)
+	if ib.itemHookHandler != nil {
+		if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
+			backupErrs = append(backupErrs, err)
+		}
 	}
 
 	if len(backupErrs) != 0 {

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -120,12 +120,10 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 
 	log.Info("Backing up item")
 
-	log.Debug("Executing pre hooks")
-	if ib.itemHookHandler != nil {
-		if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre); err != nil {
-			return false, err
-		}
-	}
+	//log.Debug("Executing pre hooks")
+	//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre); err != nil {
+	//	return false, err
+	//}
 
 	var (
 		backupErrs            []error
@@ -174,12 +172,10 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		backupErrs = append(backupErrs, err)
 
 		// if there was an error running actions, execute post hooks and return
-		log.Debug("Executing post hooks")
-		if ib.itemHookHandler != nil {
-			if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
-				backupErrs = append(backupErrs, err)
-			}
-		}
+		//log.Debug("Executing post hooks")
+		//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
+		//	backupErrs = append(backupErrs, err)
+		//}
 
 		return false, kubeerrs.NewAggregate(backupErrs)
 	}
@@ -206,12 +202,10 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		backupErrs = append(backupErrs, errs...)
 	}
 
-	log.Debug("Executing post hooks")
-	if ib.itemHookHandler != nil {
-		if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
-			backupErrs = append(backupErrs, err)
-		}
-	}
+	//log.Debug("Executing post hooks")
+	//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
+	//	backupErrs = append(backupErrs, err)
+	//}
 
 	if len(backupErrs) != 0 {
 		return false, kubeerrs.NewAggregate(backupErrs)

--- a/pkg/backup/remap_crd_version_action.go
+++ b/pkg/backup/remap_crd_version_action.go
@@ -42,7 +42,7 @@ import (
 // CRD that needs to be backed up as v1beta1.
 type RemapCRDVersionAction struct {
 	logger logrus.FieldLogger
-	// client is a controller-runtime client to dynamically fetch kubeconfig secrets of remote clusters.
+	// client is a controller-runtime client to dynamically fetch target cluster kubeconfig secrets in the management cluster.
 	client client.Client
 }
 
@@ -99,11 +99,13 @@ func (a *RemapCRDVersionAction) Execute(item runtime.Unstructured, backup *v1.Ba
 			Namespace: clusterName,
 			Name:      clusterName,
 		}
+		// a.client is the management cluster client to get kubeconfig secrets.
 		restConfig, err := remote.RESTConfig(context.Background(), a.client, cluster)
 		if err != nil {
 			return nil, nil, err
 		}
 
+		// c is the client that is used to talk to target clusters.
 		c, err := apiextensions.NewForConfig(restConfig)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/backup/remap_crd_version_action.go
+++ b/pkg/backup/remap_crd_version_action.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"encoding/json"
 
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -37,13 +41,14 @@ import (
 // RemapCRDVersionAction inspects CustomResourceDefinition and decides if it is a v1
 // CRD that needs to be backed up as v1beta1.
 type RemapCRDVersionAction struct {
-	logger        logrus.FieldLogger
-	betaCRDClient apiextv1beta1client.CustomResourceDefinitionInterface
+	logger logrus.FieldLogger
+	// client is a controller-runtime client to dynamically fetch kubeconfig secrets of remote clusters.
+	client client.Client
 }
 
 // NewRemapCRDVersionAction instantiates a new RemapCRDVersionAction plugin.
-func NewRemapCRDVersionAction(logger logrus.FieldLogger, betaCRDClient apiextv1beta1client.CustomResourceDefinitionInterface) *RemapCRDVersionAction {
-	return &RemapCRDVersionAction{logger: logger, betaCRDClient: betaCRDClient}
+func NewRemapCRDVersionAction(logger logrus.FieldLogger, client client.Client) *RemapCRDVersionAction {
+	return &RemapCRDVersionAction{logger: logger, client: client}
 }
 
 // AppliesTo selects the resources the plugin should run against. In this case, CustomResourceDefinitions.
@@ -89,7 +94,21 @@ func (a *RemapCRDVersionAction) Execute(item runtime.Unstructured, backup *v1.Ba
 	switch {
 	case hasSingleVersion(crd), hasNonStructuralSchema(crd), hasPreserveUnknownFields(crd):
 		log.Infof("CustomResourceDefinition %s appears to be v1beta1, fetching the v1beta version", crd.Name)
-		item, err = fetchV1beta1CRD(crd.Name, a.betaCRDClient)
+		clusterName := backup.Spec.StorageLocation
+		cluster := client.ObjectKey{
+			Namespace: clusterName,
+			Name:      clusterName,
+		}
+		restConfig, err := remote.RESTConfig(context.Background(), a.client, cluster)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		c, err := apiextensions.NewForConfig(restConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+		item, err = fetchV1beta1CRD(crd.Name, c.ApiextensionsV1beta1().CustomResourceDefinitions())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -19,6 +19,8 @@ package client
 import (
 	"os"
 
+	v1 "k8s.io/api/core/v1"
+
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/pkg/errors"
@@ -151,6 +153,8 @@ func (f *factory) KubebuilderClient() (kbclient.Client, error) {
 
 	scheme := runtime.NewScheme()
 	velerov1api.AddToScheme(scheme)
+	// We add v1 to our scheme so that we are also able to retrieve remove cluster kubeconfig secrets with this client.
+	v1.AddToScheme(scheme)
 	kubebuilderClient, err := kbclient.New(clientConfig, kbclient.Options{
 		Scheme: scheme,
 	})

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -86,9 +86,10 @@ func NewFactory(baseName string, config VeleroConfig) Factory {
 
 	// We didn't get the namespace via env var or config file, so use the default.
 	// Command line flags will override when BindFlags is called.
-	if f.namespace == "" {
-		f.namespace = velerov1api.DefaultNamespace
-	}
+	// TODO(freyjo): Find a better way than simply commenting this out.
+	//if f.namespace == "" {
+	//	f.namespace = velerov1api.DefaultNamespace
+	//}
 
 	f.flags.StringVar(&f.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use to talk to the Kubernetes apiserver. If unset, try the environment variable KUBECONFIG, as well as in-cluster configuration")
 	f.flags.StringVarP(&f.namespace, "namespace", "n", f.namespace, "The namespace in which Velero should operate")

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -153,7 +153,7 @@ func (f *factory) KubebuilderClient() (kbclient.Client, error) {
 
 	scheme := runtime.NewScheme()
 	velerov1api.AddToScheme(scheme)
-	// We add v1 to our scheme so that we are also able to retrieve remove cluster kubeconfig secrets with this client.
+	// We add v1 to our scheme so that we are also able to retrieve remote cluster kubeconfig secrets with this client.
 	v1.AddToScheme(scheme)
 	kubebuilderClient, err := kbclient.New(clientConfig, kbclient.Options{
 		Scheme: scheme,

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -86,10 +86,9 @@ func NewFactory(baseName string, config VeleroConfig) Factory {
 
 	// We didn't get the namespace via env var or config file, so use the default.
 	// Command line flags will override when BindFlags is called.
-	// TODO(freyjo): Find a better way than simply commenting this out.
-	//if f.namespace == "" {
-	//	f.namespace = velerov1api.DefaultNamespace
-	//}
+	if f.namespace == "" {
+		f.namespace = velerov1api.DefaultNamespace
+	}
 
 	f.flags.StringVar(&f.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use to talk to the Kubernetes apiserver. If unset, try the environment variable KUBECONFIG, as well as in-cluster configuration")
 	f.flags.StringVarP(&f.namespace, "namespace", "n", f.namespace, "The namespace in which Velero should operate")

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -46,7 +46,8 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterRestoreItemAction("velero.io/pod", newPodRestoreItemAction).
 				// TODO(freyjo): Find a better way than simply commenting this out.
 				//RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
-				RegisterRestoreItemAction("velero.io/init-restore-hook", newInitRestoreHookPodAction).
+				// TODO(freyjo): Find a better way than simply commenting this out.
+				//RegisterRestoreItemAction("velero.io/init-restore-hook", newInitRestoreHookPodAction).
 				RegisterRestoreItemAction("velero.io/service", newServiceRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/service-account", newServiceAccountRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/add-pvc-from-pod", newAddPVCFromPodRestoreItemAction).

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -40,7 +40,8 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterBackupItemAction("velero.io/pv", newPVBackupItemAction).
 				RegisterBackupItemAction("velero.io/pod", newPodBackupItemAction).
 				RegisterBackupItemAction("velero.io/service-account", newServiceAccountBackupItemAction(f)).
-				RegisterBackupItemAction("velero.io/crd-remap-version", newRemapCRDVersionAction(f)).
+				// TODO(freyjo): Find a better way than simply commenting this out.
+				//RegisterBackupItemAction("velero.io/crd-remap-version", newRemapCRDVersionAction(f)).
 				RegisterRestoreItemAction("velero.io/job", newJobRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/pod", newPodRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -40,13 +40,16 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterBackupItemAction("velero.io/pv", newPVBackupItemAction).
 				RegisterBackupItemAction("velero.io/pod", newPodBackupItemAction).
 				RegisterBackupItemAction("velero.io/service-account", newServiceAccountBackupItemAction(f)).
-				// TODO(freyjo): Find a better way than simply commenting this out.
+				// We disable the crd-remap-version plugin because otherwise CRDs with version v1beta1 won't get backed
+				// up properly.
 				//RegisterBackupItemAction("velero.io/crd-remap-version", newRemapCRDVersionAction(f)).
 				RegisterRestoreItemAction("velero.io/job", newJobRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/pod", newPodRestoreItemAction).
-				// TODO(freyjo): Find a better way than simply commenting this out.
+				// We don't want to leverage the restic features for our use case (disaster recovery without restore of
+				// disk content). Disabling the plugin is not sufficient and also required changes in other code parts.
 				//RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
-				// TODO(freyjo): Find a better way than simply commenting this out.
+				// We disable all hook functionality because hooks can block our backup and restore process.
+				// Disabling the plugin is not sufficient and also required changes in other code parts.
 				//RegisterRestoreItemAction("velero.io/init-restore-hook", newInitRestoreHookPodAction).
 				RegisterRestoreItemAction("velero.io/service", newServiceRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/service-account", newServiceAccountRestoreItemAction).

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -44,7 +44,8 @@ func NewCommand(f client.Factory) *cobra.Command {
 				//RegisterBackupItemAction("velero.io/crd-remap-version", newRemapCRDVersionAction(f)).
 				RegisterRestoreItemAction("velero.io/job", newJobRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/pod", newPodRestoreItemAction).
-				RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
+				// TODO(freyjo): Find a better way than simply commenting this out.
+				//RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
 				RegisterRestoreItemAction("velero.io/init-restore-hook", newInitRestoreHookPodAction).
 				RegisterRestoreItemAction("velero.io/service", newServiceRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/service-account", newServiceAccountRestoreItemAction).

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	snapshotv1beta1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
+	snapshotv1beta1listers "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,9 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
-
-	snapshotv1beta1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
-	snapshotv1beta1listers "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1beta1"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/internal/storage"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -59,8 +59,6 @@ import (
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
 	"github.com/vmware-tanzu/velero/pkg/volume"
-
-	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type backupController struct {
@@ -587,6 +585,7 @@ func (c *backupController) runBackup(backup *pkgbackup.Request) error {
 	}
 
 	var fatalErrs []error
+
 	if err := c.backupper.Backup(backupLog, backup, backupFile, actions, pluginManager); err != nil {
 		fatalErrs = append(fatalErrs, err)
 	}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -585,7 +585,6 @@ func (c *backupController) runBackup(backup *pkgbackup.Request) error {
 	}
 
 	var fatalErrs []error
-
 	if err := c.backupper.Backup(backupLog, backup, backupFile, actions, pluginManager); err != nil {
 		fatalErrs = append(fatalErrs, err)
 	}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -28,8 +28,6 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	snapshotv1beta1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
-	snapshotv1beta1listers "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,7 +37,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
-	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	snapshotv1beta1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
+	snapshotv1beta1listers "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1beta1"
 
 	"github.com/vmware-tanzu/velero/internal/storage"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -59,6 +59,8 @@ import (
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
 	"github.com/vmware-tanzu/velero/pkg/volume"
+
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type backupController struct {

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -217,7 +217,7 @@ func (c *backupSyncController) run() {
 				continue
 			}
 
-			// We want to keep the namespace of the found backup instead of deploying it into the one where the
+			// We want to keep the namespace of the found backup instead of deploying it into the namespace where the
 			// controller resides.
 			//backup.Namespace = c.namespace
 			backup.ResourceVersion = ""

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -217,7 +217,6 @@ func (c *backupSyncController) run() {
 				continue
 			}
 
-			backup.Namespace = c.namespace
 			backup.ResourceVersion = ""
 
 			// update the StorageLocation field and label since the name of the location

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -217,6 +217,9 @@ func (c *backupSyncController) run() {
 				continue
 			}
 
+			// We want to keep the namespace of the found backup instead of deploying it into the one where the
+			// controller resides.
+			//backup.Namespace = c.namespace
 			backup.ResourceVersion = ""
 
 			// update the StorageLocation field and label since the name of the location

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -51,8 +52,6 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // nonRestorableResources is an exclusion list  for the restoration process. Any resources
@@ -475,11 +474,13 @@ func (c *restoreController) runValidatedRestore(restore *api.Restore, info backu
 	restoreReq := pkgrestore.Request{
 		Log:              restoreLog,
 		Restore:          restore,
+		Location:         info.location,
 		Backup:           info.backup,
 		PodVolumeBackups: podVolumeBackups,
 		VolumeSnapshots:  volumeSnapshots,
 		BackupReader:     backupFile,
 	}
+
 	restoreWarnings, restoreErrors := c.restorer.Restore(restoreReq, actions, c.snapshotLocationLister, pluginManager)
 	restoreLog.Info("restore completed")
 

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -323,7 +323,7 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{
 			velerov1api.ScheduleNameLabel: restore.Spec.ScheduleName,
 		}))
-		// NOTE(freyjo): This assumes that Backups and Restores to always reside in the same namespace.
+		// NOTE: This assumes that Backups and Restores to always reside in the same namespace.
 		backups, err := c.backupLister.Backups(restore.Namespace).List(selector)
 		if err != nil {
 			restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, "Unable to list backups for schedule")
@@ -341,6 +341,7 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 		}
 	}
 
+	// NOTE: This assumes that Backups and Restores to always reside in the same namespace.
 	info, err := c.fetchBackupInfo(restore.Spec.BackupName, restore.Namespace, pluginManager)
 	if err != nil {
 		restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, fmt.Sprintf("Error retrieving backup: %v", err))
@@ -396,10 +397,8 @@ func mostRecentCompletedBackup(backups []*api.Backup) *api.Backup {
 
 // fetchBackupInfo checks the backup lister for a backup that matches the given name. If it doesn't
 // find it, it returns an error.
-// NOTE(freyjo): We adjust fetchBackupInfo to also accept a namespace explicitly. This assumes that a Restore resides
-//  in the same namespace as its corresponding Backup and BackupStorageLocation.
-//  Another idea might be to rather accept a types.NamespacedName instead of a backupName string. This would probably
-//  need adjustments in the Restore CR and CLI command to also include a reference to the namespace of the Backup.
+// NOTE: We adjust fetchBackupInfo to also accept a namespace explicitly, which will be the namespace of the
+// found Restore. As a corollary, this means that Restores and corresponding Backups must reside in the same namespace.
 func (c *restoreController) fetchBackupInfo(backupName, namespace string, pluginManager clientmgmt.Manager) (backupInfo, error) {
 	backup, err := c.backupLister.Backups(namespace).Get(backupName)
 	if err != nil {

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -52,6 +51,8 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // nonRestorableResources is an exclusion list  for the restoration process. Any resources
@@ -323,7 +324,7 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{
 			velerov1api.ScheduleNameLabel: restore.Spec.ScheduleName,
 		}))
-		// NOTE: This assumes that Backups and Restores to always reside in the same namespace.
+		// NOTE: This assumes that Backups and Restores always reside in the same namespace.
 		backups, err := c.backupLister.Backups(restore.Namespace).List(selector)
 		if err != nil {
 			restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, "Unable to list backups for schedule")
@@ -341,7 +342,7 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 		}
 	}
 
-	// NOTE: This assumes that Backups and Restores to always reside in the same namespace.
+	// NOTE: This assumes that Backups and Restores always reside in the same namespace.
 	info, err := c.fetchBackupInfo(restore.Spec.BackupName, restore.Namespace, pluginManager)
 	if err != nil {
 		restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, fmt.Sprintf("Error retrieving backup: %v", err))

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -57,6 +57,7 @@ func TestFetchBackupInfo(t *testing.T) {
 	tests := []struct {
 		name              string
 		backupName        string
+		namespace         string
 		informerLocations []*velerov1api.BackupStorageLocation
 		informerBackups   []*velerov1api.Backup
 		backupStoreBackup *velerov1api.Backup
@@ -67,6 +68,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		{
 			name:              "lister has backup",
 			backupName:        "backup-1",
+			namespace:         "velero",
 			informerLocations: []*velerov1api.BackupStorageLocation{builder.ForBackupStorageLocation("velero", "default").Provider("myCloud").Bucket("bucket").Result()},
 			informerBackups:   []*velerov1api.Backup{defaultBackup().StorageLocation("default").Result()},
 			expectedRes:       defaultBackup().StorageLocation("default").Result(),
@@ -74,6 +76,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		{
 			name:              "lister does not have a backup, but backupSvc does",
 			backupName:        "backup-1",
+			namespace:         "velero",
 			backupStoreBackup: defaultBackup().StorageLocation("default").Result(),
 			informerLocations: []*velerov1api.BackupStorageLocation{builder.ForBackupStorageLocation("velero", "default").Provider("myCloud").Bucket("bucket").Result()},
 			informerBackups:   []*velerov1api.Backup{defaultBackup().StorageLocation("default").Result()},
@@ -82,6 +85,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		{
 			name:             "no backup",
 			backupName:       "backup-1",
+			namespace:        "velero",
 			backupStoreError: errors.New("no backup here"),
 			expectedErr:      true,
 		},
@@ -144,7 +148,7 @@ func TestFetchBackupInfo(t *testing.T) {
 				backupStore.On("GetBackupMetadata", test.backupName).Return(test.backupStoreBackup, nil).Maybe()
 			}
 
-			info, err := c.fetchBackupInfo(test.backupName, pluginManager)
+			info, err := c.fetchBackupInfo(test.backupName, test.namespace, pluginManager)
 
 			require.Equal(t, test.expectedErr, err != nil)
 			assert.Equal(t, test.expectedRes, info.backup)

--- a/pkg/restore/prioritize_group_version.go
+++ b/pkg/restore/prioritize_group_version.go
@@ -221,7 +221,7 @@ func userPriorityConfigMap() (*corev1.ConfigMap, error) {
 		return nil, errors.Wrap(err, "getting Kube client")
 	}
 
-	cm, err := kc.CoreV1().ConfigMaps("velero").Get(
+	cm, err := kc.CoreV1().ConfigMaps(fc.Namespace()).Get(
 		context.Background(),
 		"enableapigroupversions",
 		metav1.GetOptions{},

--- a/pkg/restore/prioritize_group_version.go
+++ b/pkg/restore/prioritize_group_version.go
@@ -231,7 +231,7 @@ func userPriorityConfigMap() (*corev1.ConfigMap, error) {
 			return nil, nil
 		}
 
-		return nil, errors.Wrap(err, "getting enableapigroupversions config map from velero namespace")
+		return nil, errors.Wrapf(err, "getting enableapigroupversions config map from %s namespace", fc.Namespace())
 	}
 
 	return cm, nil

--- a/pkg/util/kube/cluster.go
+++ b/pkg/util/kube/cluster.go
@@ -1,0 +1,26 @@
+package kube
+
+import (
+	"context"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewClusterClients(ctx context.Context, c client.Client, cluster client.ObjectKey) (*kubernetes.Clientset, dynamic.Interface, error) {
+	restConfig, err := remote.RESTConfig(ctx, c, cluster)
+	if err != nil {
+		return nil, nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	return kubeClient, dynamicClient, nil
+}


### PR DESCRIPTION
# Please add a summary of your change

This PR disables certain features and plugins (restic, hooks) as well as enables the possibilty to backup and restore remote clusters. More precisely, velero server may run on a different cluster than the one where the backups and restores are performed. Furthermore, with this PR, Velero-specific CRs are allowed to reside in a different namespace than the Velero server.
Even though it already works, the adjustments are pretty hacky. Those should be cleaned up in a separate PR.

**PR is planned to be merged on monday April 26th** :slightly_smiling_face: 

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
