### PR TITLE
[WIP] groupresoure parsing without discovery

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubeerrs "k8s.io/apimachinery/pkg/util/errors"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/internal/hook"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -48,6 +49,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/podexec"
 	"github.com/vmware-tanzu/velero/pkg/restic"
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
+	"github.com/vmware-tanzu/velero/pkg/util/kube"
 )
 
 // BackupVersion is the current backup major version for Velero.
@@ -67,8 +69,7 @@ type Backupper interface {
 // kubernetesBackupper implements Backupper.
 type kubernetesBackupper struct {
 	backupClient           velerov1client.BackupsGetter
-	dynamicFactory         client.DynamicFactory
-	discoveryHelper        discovery.Helper
+	client                 kbclient.Client
 	podCommandExecutor     podexec.PodCommandExecutor
 	resticBackupperFactory restic.BackupperFactory
 	resticTimeout          time.Duration
@@ -102,6 +103,7 @@ func NewKubernetesBackupper(
 	backupClient velerov1client.BackupsGetter,
 	discoveryHelper discovery.Helper,
 	dynamicFactory client.DynamicFactory,
+	client kbclient.Client,
 	podCommandExecutor podexec.PodCommandExecutor,
 	resticBackupperFactory restic.BackupperFactory,
 	resticTimeout time.Duration,
@@ -109,8 +111,7 @@ func NewKubernetesBackupper(
 ) (Backupper, error) {
 	return &kubernetesBackupper{
 		backupClient:           backupClient,
-		discoveryHelper:        discoveryHelper,
-		dynamicFactory:         dynamicFactory,
+		client:                 client,
 		podCommandExecutor:     podCommandExecutor,
 		resticBackupperFactory: resticBackupperFactory,
 		resticTimeout:          resticTimeout,
@@ -203,6 +204,22 @@ type VolumeSnapshotterGetter interface {
 // back up individual resources that don't prevent the backup from continuing to be processed) are logged
 // to the backup log.
 func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Request, backupFile io.Writer, actions []velero.BackupItemAction, volumeSnapshotterGetter VolumeSnapshotterGetter) error {
+	// NOTE: This requires that the BackupStorageLocation must always be named exactly as the target cluster.
+	clusterName := backupRequest.StorageLocation.Name
+	clientSet, dynamicClient, err := kube.NewClusterClients(context.Background(), kb.client, kbclient.ObjectKey{
+		Namespace: backupRequest.Namespace,
+		Name:      clusterName,
+	})
+	if err != nil {
+		return err
+	}
+	discoveryHelper, err := discovery.NewHelper(clientSet, log)
+	if err != nil {
+		return err
+	}
+
+	dynamicFactory := client.NewDynamicFactory(dynamicClient)
+
 	gzippedData := gzip.NewWriter(backupFile)
 	defer gzippedData.Close()
 
@@ -218,18 +235,17 @@ func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Req
 	log.Infof("Including namespaces: %s", backupRequest.NamespaceIncludesExcludes.IncludesString())
 	log.Infof("Excluding namespaces: %s", backupRequest.NamespaceIncludesExcludes.ExcludesString())
 
-	backupRequest.ResourceIncludesExcludes = collections.GetResourceIncludesExcludes(kb.discoveryHelper, backupRequest.Spec.IncludedResources, backupRequest.Spec.ExcludedResources)
+	backupRequest.ResourceIncludesExcludes = collections.GetResourceIncludesExcludes(discoveryHelper, backupRequest.Spec.IncludedResources, backupRequest.Spec.ExcludedResources)
 	log.Infof("Including resources: %s", backupRequest.ResourceIncludesExcludes.IncludesString())
 	log.Infof("Excluding resources: %s", backupRequest.ResourceIncludesExcludes.ExcludesString())
 	log.Infof("Backing up all pod volumes using restic: %t", *backupRequest.Backup.Spec.DefaultVolumesToRestic)
 
-	var err error
-	backupRequest.ResourceHooks, err = getResourceHooks(backupRequest.Spec.Hooks.Resources, kb.discoveryHelper)
+	backupRequest.ResourceHooks, err = getResourceHooks(backupRequest.Spec.Hooks.Resources, discoveryHelper)
 	if err != nil {
 		return err
 	}
 
-	backupRequest.ResolvedActions, err = resolveActions(actions, kb.discoveryHelper)
+	backupRequest.ResolvedActions, err = resolveActions(actions, discoveryHelper)
 	if err != nil {
 		return err
 	}
@@ -268,8 +284,8 @@ func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Req
 	collector := &itemCollector{
 		log:                   log,
 		backupRequest:         backupRequest,
-		discoveryHelper:       kb.discoveryHelper,
-		dynamicFactory:        kb.dynamicFactory,
+		discoveryHelper:       discoveryHelper,
+		dynamicFactory:        dynamicFactory,
 		cohabitatingResources: cohabitatingResources(),
 		dir:                   tempDir,
 	}
@@ -286,8 +302,8 @@ func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Req
 	itemBackupper := &itemBackupper{
 		backupRequest:           backupRequest,
 		tarWriter:               tw,
-		dynamicFactory:          kb.dynamicFactory,
-		discoveryHelper:         kb.discoveryHelper,
+		dynamicFactory:          dynamicFactory,
+		discoveryHelper:         discoveryHelper,
 		resticBackupper:         resticBackupper,
 		resticSnapshotTracker:   newPVCSnapshotTracker(),
 		volumeSnapshotterGetter: volumeSnapshotterGetter,
@@ -402,7 +418,7 @@ func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Req
 	// we don't want to back it up, and if it's true it will already be included.
 	if backupRequest.Spec.IncludeClusterResources == nil {
 		for gr := range backedUpGroupResources {
-			kb.backupCRD(log, gr, itemBackupper)
+			kb.backupCRD(log, dynamicFactory, discoveryHelper, gr, itemBackupper)
 		}
 	}
 
@@ -442,11 +458,11 @@ func (kb *kubernetesBackupper) backupItem(log logrus.FieldLogger, gr schema.Grou
 
 // backupCRD checks if the resource is a custom resource, and if so, backs up the custom resource definition
 // associated with it.
-func (kb *kubernetesBackupper) backupCRD(log logrus.FieldLogger, gr schema.GroupResource, itemBackupper *itemBackupper) {
+func (kb *kubernetesBackupper) backupCRD(log logrus.FieldLogger, dynamicFactory client.DynamicFactory, discoveryHelper discovery.Helper, gr schema.GroupResource, itemBackupper *itemBackupper) {
 	crdGroupResource := kuberesource.CustomResourceDefinitions
 
 	log.Debugf("Getting server preferred API version for %s", crdGroupResource)
-	gvr, apiResource, err := kb.discoveryHelper.ResourceFor(crdGroupResource.WithVersion(""))
+	gvr, apiResource, err := discoveryHelper.ResourceFor(crdGroupResource.WithVersion(""))
 	if err != nil {
 		log.WithError(errors.WithStack(err)).Errorf("Error getting resolved resource for %s", crdGroupResource)
 		return
@@ -454,7 +470,7 @@ func (kb *kubernetesBackupper) backupCRD(log logrus.FieldLogger, gr schema.Group
 	log.Debugf("Got server preferred API version %s for %s", gvr.Version, crdGroupResource)
 
 	log.Debugf("Getting dynamic client for %s", gvr.String())
-	crdClient, err := kb.dynamicFactory.ClientForGroupVersionResource(gvr.GroupVersion(), apiResource, "")
+	crdClient, err := dynamicFactory.ClientForGroupVersionResource(gvr.GroupVersion(), apiResource, "")
 	if err != nil {
 		log.WithError(errors.WithStack(err)).Errorf("Error getting dynamic client for %s", crdGroupResource)
 		return

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -76,10 +76,11 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 	log = log.WithField("resource", groupResource.String())
 	log = log.WithField("namespace", namespace)
 
-	if metadata.GetLabels()["velero.io/exclude-from-backup"] == "true" {
-		log.Info("Excluding item because it has label velero.io/exclude-from-backup=true")
-		return false, nil
-	}
+	// NOTE: We don't want to allow to skip the backup of certain resources.
+	//if metadata.GetLabels()["velero.io/exclude-from-backup"] == "true" {
+	//	log.Info("Excluding item because it has label velero.io/exclude-from-backup=true")
+	//	return false, nil
+	//}
 
 	// NOTE: we have to re-check namespace & resource includes/excludes because it's possible that
 	// backupItem can be invoked by a custom action.

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -120,10 +120,12 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 
 	log.Info("Backing up item")
 
-	log.Debug("Executing pre hooks")
-	if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre); err != nil {
-		return false, err
-	}
+	// Because we don't want to use hooks.
+	//
+	//log.Debug("Executing pre hooks")
+	//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre); err != nil {
+	//	return false, err
+	//}
 
 	var (
 		backupErrs            []error
@@ -172,10 +174,12 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		backupErrs = append(backupErrs, err)
 
 		// if there was an error running actions, execute post hooks and return
-		log.Debug("Executing post hooks")
-		if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
-			backupErrs = append(backupErrs, err)
-		}
+		// Because we don't want to use hooks.
+		//
+		//log.Debug("Executing post hooks")
+		//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
+		//	backupErrs = append(backupErrs, err)
+		//}
 
 		return false, kubeerrs.NewAggregate(backupErrs)
 	}
@@ -202,10 +206,12 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		backupErrs = append(backupErrs, errs...)
 	}
 
-	log.Debug("Executing post hooks")
-	if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
-		backupErrs = append(backupErrs, err)
-	}
+	// Because we don't want to use hooks.
+	//
+	//log.Debug("Executing post hooks")
+	//if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost); err != nil {
+	//	backupErrs = append(backupErrs, err)
+	//}
 
 	if len(backupErrs) != 0 {
 		return false, kubeerrs.NewAggregate(backupErrs)

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -19,6 +19,8 @@ package client
 import (
 	"os"
 
+	v1 "k8s.io/api/core/v1"
+
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/pkg/errors"
@@ -151,6 +153,8 @@ func (f *factory) KubebuilderClient() (kbclient.Client, error) {
 
 	scheme := runtime.NewScheme()
 	velerov1api.AddToScheme(scheme)
+	// We add v1 to our scheme so that we are also able to retrieve remote cluster kubeconfig secrets with this client.
+	v1.AddToScheme(scheme)
 	kubebuilderClient, err := kbclient.New(clientConfig, kbclient.Options{
 		Scheme: scheme,
 	})

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -19,9 +19,6 @@ package plugin
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-
 	"github.com/vmware-tanzu/velero/pkg/backup"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	velerodiscovery "github.com/vmware-tanzu/velero/pkg/discovery"
@@ -43,8 +40,12 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterBackupItemAction("velero.io/crd-remap-version", newRemapCRDVersionAction(f)).
 				RegisterRestoreItemAction("velero.io/job", newJobRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/pod", newPodRestoreItemAction).
-				RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
-				RegisterRestoreItemAction("velero.io/init-restore-hook", newInitRestoreHookPodAction).
+				// We don't want to leverage the restic features for our use case (disaster recovery without restore of
+				// disk content). Disabling the plugin is not sufficient and also required changes in other code parts.
+				//RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
+				// We disable all hook functionality because hooks can block our backup and restore process.
+				// Disabling the plugin is not sufficient and also required changes in other code parts.
+				//RegisterRestoreItemAction("velero.io/init-restore-hook", newInitRestoreHookPodAction).
 				RegisterRestoreItemAction("velero.io/service", newServiceRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/service-account", newServiceAccountRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/add-pvc-from-pod", newAddPVCFromPodRestoreItemAction).
@@ -98,17 +99,14 @@ func newServiceAccountBackupItemAction(f client.Factory) veleroplugin.HandlerIni
 
 func newRemapCRDVersionAction(f client.Factory) veleroplugin.HandlerInitializer {
 	return func(logger logrus.FieldLogger) (interface{}, error) {
-		config, err := f.ClientConfig()
+		// We switch to a KubebuilderClient here because it satisfies the interface of the "main" client, with which we
+		// are able to dynamically obtain the kubeconfig secrets for the target clusters when backing up v1beta1 CRDs.
+		c, err := f.KubebuilderClient()
 		if err != nil {
 			return nil, err
 		}
 
-		client, err := apiextensions.NewForConfig(config)
-		if err != nil {
-			return nil, err
-		}
-
-		return backup.NewRemapCRDVersionAction(logger, client.ApiextensionsV1beta1().CustomResourceDefinitions()), nil
+		return backup.NewRemapCRDVersionAction(logger, c), nil
 	}
 }
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -314,14 +314,17 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	}
 
 	s := &server{
-		namespace:                           f.Namespace(),
-		metricsAddress:                      config.metricsAddress,
-		kubeClientConfig:                    clientConfig,
-		kubeClient:                          kubeClient,
-		veleroClient:                        veleroClient,
-		discoveryClient:                     veleroClient.Discovery(),
-		dynamicClient:                       dynamicClient,
-		sharedInformerFactory:               informers.NewSharedInformerFactoryWithOptions(veleroClient, 0, informers.WithNamespace(f.Namespace())),
+		namespace:        f.Namespace(),
+		metricsAddress:   config.metricsAddress,
+		kubeClientConfig: clientConfig,
+		kubeClient:       kubeClient,
+		veleroClient:     veleroClient,
+		discoveryClient:  veleroClient.Discovery(),
+		dynamicClient:    dynamicClient,
+		// We setup an informer with an empty namespace so that we register changes of resources in any namespace.
+		// This is needed because CRs like Backup, Restore, Schedule etc. reside in other namespaces than the velero
+		// server itself.
+		sharedInformerFactory:               informers.NewSharedInformerFactoryWithOptions(veleroClient, 0, informers.WithNamespace("")),
 		csiSnapshotterSharedInformerFactory: NewCSIInformerFactoryWrapper(csiSnapClient),
 		csiSnapshotClient:                   csiSnapClient,
 		ctx:                                 ctx,
@@ -359,9 +362,10 @@ func (s *server) run() error {
 		return err
 	}
 
-	if err := s.initRestic(); err != nil {
-		return err
-	}
+	// We don't need the restic features for our use case.
+	//if err := s.initRestic(); err != nil {
+	//	return err
+	//}
 
 	if err := s.runControllers(s.config.defaultVolumeSnapshotLocations); err != nil {
 		return err
@@ -584,7 +588,8 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.veleroClient.VeleroV1(),
 			s.sharedInformerFactory.Velero().V1().Backups().Lister(),
 			s.config.backupSyncPeriod,
-			s.namespace,
+			// Empty namespace so that the controller is able to retrieve Backups from any namespace.
+			"",
 			s.csiSnapshotClient,
 			s.kubeClient,
 			s.config.defaultBackupLocation,
@@ -606,6 +611,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.veleroClient.VeleroV1(),
 			s.discoveryHelper,
 			client.NewDynamicFactory(s.dynamicClient),
+			s.mgr.GetClient(),
 			podexec.NewPodCommandExecutor(s.kubeClientConfig, s.kubeClient.CoreV1().RESTClient()),
 			s.resticManager,
 			s.config.podVolumeOperationTimeout,
@@ -643,7 +649,8 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 
 	scheduleControllerRunInfo := func() controllerRunInfo {
 		scheduleController := controller.NewScheduleController(
-			s.namespace,
+			// Empty namespace so that the controller is able to retrieve Schedules from any namespace.
+			"",
 			s.veleroClient.VeleroV1(),
 			s.veleroClient.VeleroV1(),
 			s.sharedInformerFactory.Velero().V1().Schedules(),
@@ -705,6 +712,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.veleroClient.VeleroV1(),
 			s.discoveryHelper,
 			client.NewDynamicFactory(s.dynamicClient),
+			s.mgr.GetClient(),
 			s.config.restoreResourcePriorities,
 			s.kubeClient.CoreV1().Namespaces(),
 			s.resticManager,
@@ -717,7 +725,8 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 		cmd.CheckError(err)
 
 		restoreController := controller.NewRestoreController(
-			s.namespace,
+			// Empty namespace so that the controller is able to retrieve Restores from any namespace.
+			"",
 			s.sharedInformerFactory.Velero().V1().Restores(),
 			s.veleroClient.VeleroV1(),
 			s.veleroClient.VeleroV1(),

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -217,7 +217,9 @@ func (c *backupSyncController) run() {
 				continue
 			}
 
-			backup.Namespace = c.namespace
+			// We want to keep the namespace of the found backup instead of deploying it into the namespace where the
+			// controller resides.
+			//backup.Namespace = c.namespace
 			backup.ResourceVersion = ""
 
 			// update the StorageLocation field and label since the name of the location

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -324,8 +324,8 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{
 			velerov1api.ScheduleNameLabel: restore.Spec.ScheduleName,
 		}))
-
-		backups, err := c.backupLister.Backups(c.namespace).List(selector)
+		// NOTE: This assumes that Backups and Restores always reside in the same namespace.
+		backups, err := c.backupLister.Backups(restore.Namespace).List(selector)
 		if err != nil {
 			restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, "Unable to list backups for schedule")
 			return backupInfo{}
@@ -342,7 +342,8 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 		}
 	}
 
-	info, err := c.fetchBackupInfo(restore.Spec.BackupName, pluginManager)
+	// NOTE: This assumes that Backups and Restores always reside in the same namespace.
+	info, err := c.fetchBackupInfo(restore.Spec.BackupName, restore.Namespace, pluginManager)
 	if err != nil {
 		restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, fmt.Sprintf("Error retrieving backup: %v", err))
 		return backupInfo{}
@@ -397,15 +398,17 @@ func mostRecentCompletedBackup(backups []*api.Backup) *api.Backup {
 
 // fetchBackupInfo checks the backup lister for a backup that matches the given name. If it doesn't
 // find it, it returns an error.
-func (c *restoreController) fetchBackupInfo(backupName string, pluginManager clientmgmt.Manager) (backupInfo, error) {
-	backup, err := c.backupLister.Backups(c.namespace).Get(backupName)
+// NOTE: We adjust fetchBackupInfo to also accept a namespace explicitly, which will be the namespace of the
+// found Restore. As a corollary, this means that Restores and corresponding Backups must reside in the same namespace.
+func (c *restoreController) fetchBackupInfo(backupName, namespace string, pluginManager clientmgmt.Manager) (backupInfo, error) {
+	backup, err := c.backupLister.Backups(namespace).Get(backupName)
 	if err != nil {
 		return backupInfo{}, err
 	}
 
 	location := &velerov1api.BackupStorageLocation{}
 	if err := c.kbClient.Get(context.Background(), client.ObjectKey{
-		Namespace: c.namespace,
+		Namespace: namespace,
 		Name:      backup.Spec.StorageLocation,
 	}, location); err != nil {
 		return backupInfo{}, errors.WithStack(err)
@@ -471,11 +474,13 @@ func (c *restoreController) runValidatedRestore(restore *api.Restore, info backu
 	restoreReq := pkgrestore.Request{
 		Log:              restoreLog,
 		Restore:          restore,
+		Location:         info.location,
 		Backup:           info.backup,
 		PodVolumeBackups: podVolumeBackups,
 		VolumeSnapshots:  volumeSnapshots,
 		BackupReader:     backupFile,
 	}
+
 	restoreWarnings, restoreErrors := c.restorer.Restore(restoreReq, actions, c.snapshotLocationLister, pluginManager)
 	restoreLog.Info("restore completed")
 

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -57,6 +57,7 @@ func TestFetchBackupInfo(t *testing.T) {
 	tests := []struct {
 		name              string
 		backupName        string
+		namespace         string
 		informerLocations []*velerov1api.BackupStorageLocation
 		informerBackups   []*velerov1api.Backup
 		backupStoreBackup *velerov1api.Backup
@@ -67,6 +68,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		{
 			name:              "lister has backup",
 			backupName:        "backup-1",
+			namespace:         "velero",
 			informerLocations: []*velerov1api.BackupStorageLocation{builder.ForBackupStorageLocation("velero", "default").Provider("myCloud").Bucket("bucket").Result()},
 			informerBackups:   []*velerov1api.Backup{defaultBackup().StorageLocation("default").Result()},
 			expectedRes:       defaultBackup().StorageLocation("default").Result(),
@@ -74,6 +76,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		{
 			name:              "lister does not have a backup, but backupSvc does",
 			backupName:        "backup-1",
+			namespace:         "velero",
 			backupStoreBackup: defaultBackup().StorageLocation("default").Result(),
 			informerLocations: []*velerov1api.BackupStorageLocation{builder.ForBackupStorageLocation("velero", "default").Provider("myCloud").Bucket("bucket").Result()},
 			informerBackups:   []*velerov1api.Backup{defaultBackup().StorageLocation("default").Result()},
@@ -82,6 +85,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		{
 			name:             "no backup",
 			backupName:       "backup-1",
+			namespace:        "velero",
 			backupStoreError: errors.New("no backup here"),
 			expectedErr:      true,
 		},
@@ -144,7 +148,7 @@ func TestFetchBackupInfo(t *testing.T) {
 				backupStore.On("GetBackupMetadata", test.backupName).Return(test.backupStoreBackup, nil).Maybe()
 			}
 
-			info, err := c.fetchBackupInfo(test.backupName, pluginManager)
+			info, err := c.fetchBackupInfo(test.backupName, test.namespace, pluginManager)
 
 			require.Equal(t, test.expectedErr, err != nil)
 			assert.Equal(t, test.expectedRes, info.backup)

--- a/pkg/restore/prioritize_group_version.go
+++ b/pkg/restore/prioritize_group_version.go
@@ -221,7 +221,7 @@ func userPriorityConfigMap() (*corev1.ConfigMap, error) {
 		return nil, errors.Wrap(err, "getting Kube client")
 	}
 
-	cm, err := kc.CoreV1().ConfigMaps("velero").Get(
+	cm, err := kc.CoreV1().ConfigMaps(fc.Namespace()).Get(
 		context.Background(),
 		"enableapigroupversions",
 		metav1.GetOptions{},
@@ -231,7 +231,7 @@ func userPriorityConfigMap() (*corev1.ConfigMap, error) {
 			return nil, nil
 		}
 
-		return nil, errors.Wrap(err, "getting enableapigroupversions config map from velero namespace")
+		return nil, errors.Wrapf(err, "getting enableapigroupversions config map from %s namespace", fc.Namespace())
 	}
 
 	return cm, nil

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/internal/hook"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -82,6 +83,7 @@ type Request struct {
 	*velerov1api.Restore
 
 	Log              logrus.FieldLogger
+	Location         *velerov1api.BackupStorageLocation
 	Backup           *velerov1api.Backup
 	PodVolumeBackups []*velerov1api.PodVolumeBackup
 	VolumeSnapshots  []*volume.Snapshot
@@ -101,8 +103,7 @@ type Restorer interface {
 // kubernetesRestorer implements Restorer for restoring into a Kubernetes cluster.
 type kubernetesRestorer struct {
 	restoreClient              velerov1client.RestoresGetter
-	discoveryHelper            discovery.Helper
-	dynamicFactory             client.DynamicFactory
+	client                     kbclient.Client
 	namespaceClient            corev1.NamespaceInterface
 	resticRestorerFactory      restic.RestorerFactory
 	resticTimeout              time.Duration
@@ -120,6 +121,7 @@ func NewKubernetesRestorer(
 	restoreClient velerov1client.RestoresGetter,
 	discoveryHelper discovery.Helper,
 	dynamicFactory client.DynamicFactory,
+	client kbclient.Client,
 	resourcePriorities []string,
 	namespaceClient corev1.NamespaceInterface,
 	resticRestorerFactory restic.RestorerFactory,
@@ -131,9 +133,7 @@ func NewKubernetesRestorer(
 ) (Restorer, error) {
 	return &kubernetesRestorer{
 		restoreClient:              restoreClient,
-		discoveryHelper:            discoveryHelper,
-		dynamicFactory:             dynamicFactory,
-		namespaceClient:            namespaceClient,
+		client:                     client,
 		resticRestorerFactory:      resticRestorerFactory,
 		resticTimeout:              resticTimeout,
 		resourceTerminatingTimeout: resourceTerminatingTimeout,
@@ -162,6 +162,21 @@ func (kr *kubernetesRestorer) Restore(
 	snapshotLocationLister listers.VolumeSnapshotLocationLister,
 	volumeSnapshotterGetter VolumeSnapshotterGetter,
 ) (Result, Result) {
+	// NOTE: This requires that the BackupStorageLocation must always be named exactly as the target cluster.
+	clusterName := req.Location.Name
+	clientSet, dynamicClient, err := kube.NewClusterClients(go_context.Background(), kr.client, kbclient.ObjectKey{
+		Namespace: clusterName,
+		Name:      clusterName,
+	})
+	if err != nil {
+		return Result{}, Result{Velero: []string{err.Error()}}
+	}
+	discoveryHelper, err := discovery.NewHelper(clientSet, kr.logger)
+	if err != nil {
+		return Result{}, Result{Velero: []string{err.Error()}}
+	}
+	dynamicFactory := client.NewDynamicFactory(dynamicClient)
+	namespaceClient := clientSet.CoreV1().Namespaces()
 	// metav1.LabelSelectorAsSelector converts a nil LabelSelector to a
 	// Nothing Selector, i.e. a selector that matches nothing. We want
 	// a selector that matches everything. This can be accomplished by
@@ -178,7 +193,7 @@ func (kr *kubernetesRestorer) Restore(
 
 	// Get resource includes-excludes.
 	resourceIncludesExcludes := collections.GetResourceIncludesExcludes(
-		kr.discoveryHelper,
+		discoveryHelper,
 		req.Restore.Spec.IncludedResources,
 		req.Restore.Spec.ExcludedResources,
 	)
@@ -188,7 +203,7 @@ func (kr *kubernetesRestorer) Restore(
 		Includes(req.Restore.Spec.IncludedNamespaces...).
 		Excludes(req.Restore.Spec.ExcludedNamespaces...)
 
-	resolvedActions, err := resolveActions(actions, kr.discoveryHelper)
+	resolvedActions, err := resolveActions(actions, discoveryHelper)
 	if err != nil {
 		return Result{}, Result{Velero: []string{err.Error()}}
 	}
@@ -248,9 +263,9 @@ func (kr *kubernetesRestorer) Restore(
 		chosenGrpVersToRestore:     make(map[string]ChosenGroupVersion),
 		selector:                   selector,
 		log:                        req.Log,
-		dynamicFactory:             kr.dynamicFactory,
+		dynamicFactory:             dynamicFactory,
 		fileSystem:                 kr.fileSystem,
-		namespaceClient:            kr.namespaceClient,
+		namespaceClient:            namespaceClient,
 		actions:                    resolvedActions,
 		volumeSnapshotterGetter:    volumeSnapshotterGetter,
 		resticRestorer:             resticRestorer,
@@ -264,7 +279,7 @@ func (kr *kubernetesRestorer) Restore(
 		restoredItems:              make(map[velero.ResourceIdentifier]struct{}),
 		renamedPVs:                 make(map[string]string),
 		pvRenamer:                  kr.pvRenamer,
-		discoveryHelper:            kr.discoveryHelper,
+		discoveryHelper:            discoveryHelper,
 		resourcePriorities:         kr.resourcePriorities,
 		resourceRestoreHooks:       resourceRestoreHooks,
 		hooksErrs:                  make(chan error),
@@ -590,17 +605,21 @@ func (ctx *restoreContext) execute() (Result, Result) {
 	}
 	ctx.log.Info("Done waiting for all restic restores to complete")
 
+	// Because we don't want to use hooks.
+	//
 	// Wait for all post-restore exec hooks with same logic as restic wait above.
-	go func() {
-		ctx.log.Info("Waiting for all post-restore-exec hooks to complete")
+	//go func() {
+	//	ctx.log.Info("Waiting for all post-restore-exec hooks to complete")
 
-		ctx.hooksWaitGroup.Wait()
-		close(ctx.hooksErrs)
-	}()
-	for err := range ctx.hooksErrs {
-		errs.Velero = append(errs.Velero, err.Error())
-	}
-	ctx.log.Info("Done waiting for all post-restore exec hooks to complete")
+	//	ctx.hooksWaitGroup.Wait()
+	//	close(ctx.hooksErrs)
+	//}()
+	// Because we don't want to use hooks.
+	//
+	//for err := range ctx.hooksErrs {
+	//	errs.Velero = append(errs.Velero, err.Error())
+	//}
+	//ctx.log.Info("Done waiting for all post-restore exec hooks to complete")
 
 	return warnings, errs
 }
@@ -1376,29 +1395,33 @@ func (ctx *restoreContext) waitExec(createdObj *unstructured.Unstructured) {
 		pod := new(v1.Pod)
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(createdObj.UnstructuredContent(), &pod); err != nil {
 			ctx.log.WithError(err).Error("error converting unstructured pod")
-			ctx.hooksErrs <- err
+			// Because we don't want to use hooks.
+			//
+			//ctx.hooksErrs <- err
 			return
 		}
-		execHooksByContainer, err := hook.GroupRestoreExecHooks(
-			ctx.resourceRestoreHooks,
-			pod,
-			ctx.log,
-		)
-		if err != nil {
-			ctx.log.WithError(err).Errorf("error getting exec hooks for pod %s/%s", pod.Namespace, pod.Name)
-			ctx.hooksErrs <- err
-			return
-		}
+		// Because we don't want to use hooks.
+		//
+		//execHooksByContainer, err := hook.GroupRestoreExecHooks(
+		//	ctx.resourceRestoreHooks,
+		//	pod,
+		//	ctx.log,
+		//)
+		//if err != nil {
+		//	ctx.log.WithError(err).Errorf("error getting exec hooks for pod %s/%s", pod.Namespace, pod.Name)
+		//	ctx.hooksErrs <- err
+		//	return
+		//}
 
-		if errs := ctx.waitExecHookHandler.HandleHooks(ctx.hooksContext, ctx.log, pod, execHooksByContainer); len(errs) > 0 {
-			ctx.log.WithError(kubeerrs.NewAggregate(errs)).Error("unable to successfully execute post-restore hooks")
-			ctx.hooksCancelFunc()
+		//if errs := ctx.waitExecHookHandler.HandleHooks(ctx.hooksContext, ctx.log, pod, execHooksByContainer); len(errs) > 0 {
+		//	ctx.log.WithError(kubeerrs.NewAggregate(errs)).Error("unable to successfully execute post-restore hooks")
+		//	ctx.hooksCancelFunc()
 
-			for _, err := range errs {
-				// Errors are already logged in the HandleHooks method.
-				ctx.hooksErrs <- err
-			}
-		}
+		//	for _, err := range errs {
+		//		// Errors are already logged in the HandleHooks method.
+		//		ctx.hooksErrs <- err
+		//	}
+		//}
 	}()
 }
 

--- a/pkg/util/kube/cluster.go
+++ b/pkg/util/kube/cluster.go
@@ -1,0 +1,26 @@
+package kube
+
+import (
+	"context"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewClusterClients(ctx context.Context, c client.Client, cluster client.ObjectKey) (*kubernetes.Clientset, dynamic.Interface, error) {
+	restConfig, err := remote.RESTConfig(ctx, c, cluster)
+	if err != nil {
+		return nil, nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	return kubeClient, dynamicClient, nil
+}


### PR DESCRIPTION
This PR does not propagate the error if a resource cannot be resolved via discovery. Instead it tries to parse its GroupResource directly via schema. This mitigates cases where resources depend on other resources/APIs to be present during restore. E.g. when restoring CRs and corresponding CRDs at the same time.

Will be fixed in 1.6.1 via https://github.com/vmware-tanzu/velero/pull/3845#pullrequestreview-683237183