### PR TITLE
pkg/restore/restore.go: remove case hasDeleteReclaimPolicy

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1115,6 +1115,8 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 			// want to dynamically re-provision it.
 			return warnings, errs
 
+		// CaaS: we want to have the PVs with the reclaim policy Delete also to be restored as it-is (i.e., with correct claimRef)
+		//
 		//case hasDeleteReclaimPolicy(obj.Object):
 		//	ctx.log.Infof("Dynamically re-provisioning persistent volume because it doesn't have a snapshot and its reclaim policy is Delete.")
 		//	ctx.pvsToProvision.Insert(name)

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1115,13 +1115,13 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 			// want to dynamically re-provision it.
 			return warnings, errs
 
-		case hasDeleteReclaimPolicy(obj.Object):
-			ctx.log.Infof("Dynamically re-provisioning persistent volume because it doesn't have a snapshot and its reclaim policy is Delete.")
-			ctx.pvsToProvision.Insert(name)
-
-			// Return early because we don't want to restore the PV itself, we
-			// want to dynamically re-provision it.
-			return warnings, errs
+		//case hasDeleteReclaimPolicy(obj.Object):
+		//	ctx.log.Infof("Dynamically re-provisioning persistent volume because it doesn't have a snapshot and its reclaim policy is Delete.")
+		//	ctx.pvsToProvision.Insert(name)
+		//
+		//	// Return early because we don't want to restore the PV itself, we
+		//	// want to dynamically re-provision it.
+		//	return warnings, errs
 
 		default:
 			ctx.log.Infof("Restoring persistent volume as-is because it doesn't have a snapshot and its reclaim policy is not Delete.")

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1115,7 +1115,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 			// want to dynamically re-provision it.
 			return warnings, errs
 
-		// CaaS: we want to have the PVs with the reclaim policy Delete also to be restored as it-is (i.e., with correct claimRef)
+		// CaaS: we want to have the PVs with the reclaim policy Delete also to be restored as-is (i.e., with correct claimRef)
 		//
 		//case hasDeleteReclaimPolicy(obj.Object):
 		//	ctx.log.Infof("Dynamically re-provisioning persistent volume because it doesn't have a snapshot and its reclaim policy is Delete.")


### PR DESCRIPTION
Our recent/new `ni_restore` process is as following

* create a nightly
* deploy our test app with `cinder` and `cinder-retain` PVCs
* create a Velero backup
* purge the cluster, except for PVCs and backups
* create the nightly again
* restore the Velero backup

Unfortunately, the `cinder` PVs will be re-provisioned without the correct claimRefs to the cinder volumes.

Workaround is this PR to create them like a PV with the reclaim policy `Retain`