### PR TITLE
log: never warn if no default backup storage location is set

### DIFF
--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -169,7 +169,8 @@ func (r *BackupStorageLocationReconciler) logReconciledPhase(defaultFound bool, 
 		log.Warnf("Unavailable backup storage locations detected: available/unavailable/unknown: %v/%v/%v, %s)", numAvailable, numUnavailable, numUnknown, strings.Join(errs, "; "))
 	}
 
-	if !defaultFound {
+	// CaaS: we never set a default backup storage location.
+	if !defaultFound && len(locationList.Items) == 0 {
 		log.Warn("There is no existing backup storage location set as default. Please see `velero backup-location -h` for options.")
 	}
 }


### PR DESCRIPTION
To suppress warnings like

```
time="2021-10-18T12:35:02Z" level=warning msg="There is no existing backup storage location set as default. Please see `velero backup-location -h` for options." controller=backup-storage-location logSource="pkg/controller/backup_storage_location_controller.go:173"
```