### PR TITLE
Fix kubeconfig clusterName from backupstoragelocation

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -208,6 +208,7 @@ type VolumeSnapshotterGetter interface {
 // back up individual resources that don't prevent the backup from continuing to be processed) are logged
 // to the backup log.
 func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Request, backupFile io.Writer, actions []velero.BackupItemAction, volumeSnapshotterGetter VolumeSnapshotterGetter) error {
+	// NOTE: The BackupStorageLocation name must be postfixed by the cluster name, separated by a dash.
 	clusterName := strings.Split(backupRequest.StorageLocation.Name, "-")[0]
 	clientSet, dynamicClient, err := kube.NewClusterClients(context.Background(), kb.client, kbclient.ObjectKey{
 		Namespace: backupRequest.Namespace,

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -207,8 +208,7 @@ type VolumeSnapshotterGetter interface {
 // back up individual resources that don't prevent the backup from continuing to be processed) are logged
 // to the backup log.
 func (kb *kubernetesBackupper) Backup(log logrus.FieldLogger, backupRequest *Request, backupFile io.Writer, actions []velero.BackupItemAction, volumeSnapshotterGetter VolumeSnapshotterGetter) error {
-	// NOTE: This requires that the BackupStorageLocation must always be named exactly as the target cluster.
-	clusterName := backupRequest.StorageLocation.Name
+	clusterName := strings.Split(backupRequest.StorageLocation.Name, "-")[0]
 	clientSet, dynamicClient, err := kube.NewClusterClients(context.Background(), kb.client, kbclient.ObjectKey{
 		Namespace: backupRequest.Namespace,
 		Name:      clusterName,

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -162,6 +162,7 @@ func (kr *kubernetesRestorer) Restore(
 	snapshotLocationLister listers.VolumeSnapshotLocationLister,
 	volumeSnapshotterGetter VolumeSnapshotterGetter,
 ) (Result, Result) {
+	// NOTE: The BackupStorageLocation name must be postfixed by the cluster name, separated by a dash.
 	clusterName := strings.Split(req.Location.Name, "-")[0]
 	clientSet, dynamicClient, err := kube.NewClusterClients(go_context.Background(), kr.client, kbclient.ObjectKey{
 		Namespace: clusterName,

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -162,8 +162,7 @@ func (kr *kubernetesRestorer) Restore(
 	snapshotLocationLister listers.VolumeSnapshotLocationLister,
 	volumeSnapshotterGetter VolumeSnapshotterGetter,
 ) (Result, Result) {
-	// NOTE: This requires that the BackupStorageLocation must always be named exactly as the target cluster.
-	clusterName := req.Location.Name
+	clusterName := strings.Split(req.Location.Name, "-")[0]
 	clientSet, dynamicClient, err := kube.NewClusterClients(go_context.Background(), kr.client, kbclient.ObjectKey{
 		Namespace: clusterName,
 		Name:      clusterName,


### PR DESCRIPTION
We added a separate `BackupStorageLocation` per cluster.
Thus, we have to trim everything after the dash to get the correct cluster name.