### PR TITLE
Re-add the CSI annotation to PVs on restore

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1569,7 +1569,7 @@ func resetVolumeBindingInfo(obj *unstructured.Unstructured) *unstructured.Unstru
 
 	// Remove the provisioned-by annotation which signals that the persistent
 	// volume was dynamically provisioned; it is now statically provisioned.
-	delete(annotations, KubeAnnDynamicallyProvisioned)
+	// delete(annotations, KubeAnnDynamicallyProvisioned)
 
 	// GetAnnotations returns a copy, so we have to set them again.
 	obj.SetAnnotations(annotations)


### PR DESCRIPTION
After we've restored the PVs we are not able to delete them because of the missing annotation.

See https://bugzilla.redhat.com/show_bug.cgi?id=1952820