### PR TITLE
fix: Skip syncing the backup which doesn't contain backup metadata

### DIFF
--- a/changelogs/unreleased/7081-ywk253100
+++ b/changelogs/unreleased/7081-ywk253100
@@ -1,0 +1,1 @@
+Skip syncing the backup which doesn't contain backup metadata

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -211,6 +211,16 @@ func (c *backupSyncController) run() {
 			log = log.WithField("backup", backupName)
 			log.Info("Attempting to sync backup into cluster")
 
+			exist, err := backupStore.BackupExists(location.Spec.ObjectStorage.Bucket, backupName)
+			if err != nil {
+				log.WithError(errors.WithStack(err)).Error("Error checking backup exist from backup store")
+				continue
+			}
+			if !exist {
+				log.Debugf("backup %s doesn't exist in backup store, skip", backupName)
+				continue
+			}
+
 			backup, err := backupStore.GetBackupMetadata(backupName)
 			if err != nil {
 				log.WithError(errors.WithStack(err)).Error("Error getting backup metadata from backup store")

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -370,6 +370,7 @@ func TestBackupSyncControllerRun(t *testing.T) {
 					backupNames = append(backupNames, bucket.backup.Name)
 					backupStore.On("GetBackupMetadata", bucket.backup.Name).Return(bucket.backup, nil)
 					backupStore.On("GetPodVolumeBackups", bucket.backup.Name).Return(bucket.podVolumeBackups, nil)
+					backupStore.On("BackupExists", "bucket-1", backup.backup.Name).Return(true, nil)
 				}
 				backupStore.On("ListBackups").Return(backupNames, nil)
 			}


### PR DESCRIPTION
Cherry pick of: Skip syncing the backup which doesn't contain backup metadata

From https://github.com/vmware-tanzu/velero/pull/7081

